### PR TITLE
Fixed a bug in RhinoList<T> copy constructor

### DIFF
--- a/dotnet/opennurbs/opennurbs_list.cs
+++ b/dotnet/opennurbs/opennurbs_list.cs
@@ -182,10 +182,10 @@ namespace Rhino.Collections
     public RhinoList(RhinoList<T> list)
     {
       if (list == null) { throw new ArgumentNullException("list"); }
-
-      //Set capacity to match.
-      Capacity = list.Capacity;
-
+      
+      // initialize items array at same capacity
+      m_items = new T[list.Capacity];
+      
       if (list.m_size > 0)
       {
         Array.Copy(list.m_items, m_items, list.m_items.Length);


### PR DESCRIPTION
as the m_items array was not initialized.

PS: 
I hope this approach works for you, if not let me know & I'll report bugs in the newsgroup rather than issue pull requests here.

All the best,
Menno
